### PR TITLE
feat(dependabot): skip validate_dvc_pipeline job when dependabot make…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
   validate_dvc_pipeline:
     runs-on: ubuntu-latest
     needs: test_and_lint
+    # This condition skips the entire job for Dependabot pull requests,
+    # preventing failures due to missing secrets.
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5


### PR DESCRIPTION
validate_dvc_pipeline job needs secrets which are not provided to a external pull request hence we skip the particular job for that case e.g. a dependabot pull request.
closes #11 