### PR TITLE
Revert "chore(deps): bump python-json-logger from 3.3.0 to 4.0.0"

### DIFF
--- a/airflow/requirements.airflow.txt
+++ b/airflow/requirements.airflow.txt
@@ -29,7 +29,7 @@ pyyaml==6.0.2
 pendulum==3.1.0  
 
 # for logger
-python-json-logger==4.0.0
+python-json-logger==3.3.0
 # node js is installed for gemini cli will need to be removed later.
 
 # Experiment tracking and model versioning with mlflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ pyyaml==6.0.2
 pendulum==3.1.0  
 
 # for logger
-python-json-logger==4.0.0
+python-json-logger==3.3.0
 # node js is installed for gemini cli will need to be removed later.
 
 # Experiment tracking and model versioning with mlflow

--- a/uv.lock
+++ b/uv.lock
@@ -3582,11 +3582,11 @@ wheels = [
 
 [[package]]
 name = "python-json-logger"
-version = "4.0.0"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/bf/eca6a3d43db1dae7070f70e160ab20b807627ba953663ba07928cdd3dc58/python_json_logger-4.0.0.tar.gz", hash = "sha256:f58e68eb46e1faed27e0f574a55a0455eecd7b8a5b88b85a784519ba3cff047f", size = 17683, upload-time = "2025-10-06T04:15:18.984Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/d3144a0bceede957f961e975f3752760fbe390d57fbe194baf709d8f1f7b/python_json_logger-3.3.0.tar.gz", hash = "sha256:12b7e74b17775e7d565129296105bbe3910842d9d0eb083fc83a6a617aa8df84", size = 16642, upload-time = "2025-03-07T07:08:27.301Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e5/fecf13f06e5e5f67e8837d777d1bc43fac0ed2b77a676804df5c34744727/python_json_logger-4.0.0-py3-none-any.whl", hash = "sha256:af09c9daf6a813aa4cc7180395f50f2a9e5fa056034c9953aec92e381c5ba1e2", size = 15548, upload-time = "2025-10-06T04:15:17.553Z" },
+    { url = "https://files.pythonhosted.org/packages/08/20/0f2523b9e50a8052bc6a8b732dfc8568abbdc42010aef03a2d750bdab3b2/python_json_logger-3.3.0-py3-none-any.whl", hash = "sha256:dd980fae8cffb24c13caf6e158d3d61c0d6d22342f932cb6e9deedab3d35eec7", size = 15163, upload-time = "2025-03-07T07:08:25.627Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Reverts dakshvanshaj/flights-price-prediction-mlops#6 due to breaking changes in a major update.